### PR TITLE
Add iOS SwiftUI version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# OpenRouterFree iOS
+
+This folder contains a minimal SwiftUI application that allows using the OpenRouter API on iOS devices.
+
+## Building
+
+Open the `ios/OpenRouterChat` folder in Xcode and build for your desired iPhone target. The app stores the API key securely in the iOS Keychain.
+
+## Usage
+
+1. Launch the app.
+2. Tap the **API Key** button to enter your OpenRouter API key. The key is stored in the Keychain and automatically loaded on subsequent launches.
+3. Type a message and press **Send**. The response from the model appears in the chat history.
+
+This is a simplified port of the original Tkinter application written in Python.

--- a/ios/OpenRouterChat/APIManager.swift
+++ b/ios/OpenRouterChat/APIManager.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+class APIManager {
+    static let shared = APIManager()
+    private init() {}
+
+    func send(messages: [[String: String]], apiKey: String) async throws -> String? {
+        guard let url = URL(string: "https://openrouter.ai/api/v1/chat/completions") else { return nil }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let payload: [String: Any] = ["model": "openrouter/cypher-alpha:free", "messages": messages, "stream": false]
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            throw NSError(domain: "API", code: status, userInfo: [NSLocalizedDescriptionKey: "Bad response: \(status)"])
+        }
+        if let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let choices = obj["choices"] as? [[String: Any]],
+           let msg = choices.first?["message"] as? [String: Any],
+           let content = msg["content"] as? String {
+            return content
+        }
+        return nil
+    }
+}

--- a/ios/OpenRouterChat/ContentView.swift
+++ b/ios/OpenRouterChat/ContentView.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+struct ChatMessage: Identifiable {
+    let id = UUID()
+    let role: String
+    let content: String
+}
+
+struct ContentView: View {
+    @State private var apiKey: String = KeychainHelper.shared.read(key: "OPENROUTER_KEY") ?? ""
+    @State private var input: String = ""
+    @State private var messages: [ChatMessage] = []
+    @State private var isShowingKeyEntry = false
+    @State private var isLoading = false
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                ScrollViewReader { reader in
+                    ScrollView {
+                        LazyVStack(alignment: .leading) {
+                            ForEach(messages) { msg in
+                                HStack {
+                                    Text(msg.role == "user" ? "You:" : "AI:")
+                                        .bold()
+                                    Text(msg.content)
+                                    Spacer()
+                                }
+                                .padding(4)
+                            }
+                        }
+                    }
+                    .onChange(of: messages.count) { _ in
+                        if let last = messages.last?.id {
+                            withAnimation { reader.scrollTo(last, anchor: .bottom) }
+                        }
+                    }
+                }
+
+                HStack {
+                    TextField("Message", text: $input)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .disabled(isLoading)
+                    Button("Send") {
+                        sendMessage()
+                    }
+                    .disabled(isLoading || input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+                .padding()
+            }
+            .navigationTitle("OpenRouter Chat")
+            .toolbar {
+                Button("API Key") { isShowingKeyEntry = true }
+            }
+            .sheet(isPresented: $isShowingKeyEntry) {
+                NavigationView {
+                    Form {
+                        SecureField("API Key", text: $apiKey)
+                    }
+                    .navigationTitle("Set API Key")
+                    .toolbar {
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("Save") {
+                                KeychainHelper.shared.save(key: "OPENROUTER_KEY", value: apiKey)
+                                isShowingKeyEntry = false
+                            }
+                        }
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Cancel") { isShowingKeyEntry = false }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    func sendMessage() {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        guard !apiKey.isEmpty else {
+            isShowingKeyEntry = true
+            return
+        }
+        let userMsg = ChatMessage(role: "user", content: trimmed)
+        messages.append(userMsg)
+        input = ""
+        isLoading = true
+
+        Task {
+            do {
+                if let resp = try await APIManager.shared.send(messages: messages.map { ["role": $0.role, "content": $0.content] }, apiKey: apiKey) {
+                    let aiMsg = ChatMessage(role: "assistant", content: resp)
+                    messages.append(aiMsg)
+                }
+            } catch {
+                messages.append(ChatMessage(role: "assistant", content: "Error: \(error.localizedDescription)"))
+            }
+            isLoading = false
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/ios/OpenRouterChat/KeychainHelper.swift
+++ b/ios/OpenRouterChat/KeychainHelper.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Security
+
+class KeychainHelper {
+    static let shared = KeychainHelper()
+    private init() {}
+
+    func save(key: String, value: String) {
+        if let data = value.data(using: .utf8) {
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrAccount as String: key,
+                kSecValueData as String: data
+            ]
+            SecItemDelete(query as CFDictionary)
+            SecItemAdd(query as CFDictionary, nil)
+        }
+    }
+
+    func read(key: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecSuccess, let data = result as? Data, let str = String(data: data, encoding: .utf8) {
+            return str
+        }
+        return nil
+    }
+}

--- a/ios/OpenRouterChat/OpenRouterChatApp.swift
+++ b/ios/OpenRouterChat/OpenRouterChatApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct OpenRouterChatApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add SwiftUI application for iOS with secure Keychain API-key storage
- document how to build and use the iOS app

## Testing
- `swift --version`
- `swiftc ios/OpenRouterChat/*.swift -o /tmp/app` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_687ea56613748330b0714b994f41b62f